### PR TITLE
Add lodash to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bluebird": "^2.10.0",
     "bunyan": "^1.4.0",
     "js-yaml": "^3.3.1",
+    "lodash": "^4.10.0",
     "oauth": "^0.9.14",
     "restify": "^3.0.3",
     "superagent": "^1.2.0",


### PR DESCRIPTION
Lodash is used in the project but had been ommited from the package.json
file which caused the application to fail to run properly.
