### PR TITLE
Fix/lliss/stash subdirs

### DIFF
--- a/lib/StashHandler.js
+++ b/lib/StashHandler.js
@@ -226,7 +226,12 @@ StashHandler.prototype.pushHandler = function(event, cb) {
   try {
     var link = payload.changesets.values[0].links.self[0].href;
     var parts = url.parse(link);
-    stashHost = util.format('%s//%s', parts.protocol, parts.host);
+    var path = parts.pathname.split('/projects/');
+    var subdir = '';
+    if (path[0] !== '') {
+      subdir = path[0];
+    }
+    stashHost = util.format('%s//%s', parts.protocol, parts.host, subdir);
   }
   catch (e) {
     self.log.error({err: e, event: event},


### PR DESCRIPTION
This change should allow for stash instance that live at a subdirectory
`http://stash.instance/stash`
to work. Currently only
`http://stash.instance`
will work