### PR TITLE
Fix context path prefix by including the parsed subdir in the returned string.

### DIFF
--- a/lib/StashHandler.js
+++ b/lib/StashHandler.js
@@ -231,7 +231,7 @@ StashHandler.prototype.pushHandler = function(event, cb) {
     if (path[0] !== '') {
       subdir = path[0];
     }
-    stashHost = util.format('%s//%s', parts.protocol, parts.host, subdir);
+    stashHost = util.format('%s//%s%s', parts.protocol, parts.host, subdir);
   }
   catch (e) {
     self.log.error({err: e, event: event},


### PR DESCRIPTION
In the original PR created by @lliss which I merged the subdir was found but was not included in the pattern passed to `util.format` which ended up introducing a space.

This is already in prod in a hotfix. Can be tested with our new http://bbs2.probo.ci/bbs instance. See Howard for an account.

The problem was doing the first rather than the second here:
```
$ node
> require('util').format('%s/%s', 'a', 'b', 'c');
'a/b c'
> require('util').format('%s/%s%s', 'a', 'b', 'c');
'a/bc'
```