### PR TITLE
Create running state

### DIFF
--- a/lib/StashHandler.js
+++ b/lib/StashHandler.js
@@ -295,11 +295,13 @@ StashHandler.prototype.buildStatusUpdateHandler = function(update, build, cb) {
   self.log.info({update: update, build_id: build.id}, 'Got build status update');
 
   // maps github-like statuses to ones that stash accepts
+  // https://developer.atlassian.com/stash/docs/latest/how-tos/updating-build-status-for-commits.html
   var stateMap = {
     success: 'SUCCESSFUL',
     pending: 'INPROGRESS',
     error: 'FAILED',
     fail: 'FAILED',
+    running: 'INPROGRESS',
   };
 
   var statusInfo = {

--- a/lib/StashHandler.js
+++ b/lib/StashHandler.js
@@ -313,7 +313,7 @@ StashHandler.prototype.buildStatusUpdateHandler = function(update, build, cb) {
 
   // handle unknown state
   if (!statusInfo.state) {
-    statusInfo.state = 'PENDING';
+    statusInfo.state = 'INPROGRESS';
     statusInfo.description = (statusInfo.description || '') + ' (original state:' + update.state + ')';
   }
 


### PR DESCRIPTION
The container manager has a "running" state as of https://github.com/ProboCI/probo/pull/98

However, Bitbucket Server does not accept that as a valid state. Thus, this PR remaps "running" to "INPROGRESS".

**Dependencies**
https://github.com/ProboCI/probo/pull/98

**To test**
Make some builds on Bitbucket Server (http://bbs.probo.ci), and ensure the correct task states are publishing.